### PR TITLE
Do not fail on symlinks that point to non-empty files, use default tar behavior

### DIFF
--- a/_examples/main.go
+++ b/_examples/main.go
@@ -54,9 +54,14 @@ func createExampleData() (string, string) {
 		os.Exit(1)
 	}
 
-	_, err = os.Create(filepath.Join(subDirectory, "my_file.txt"))
-	if err != nil {
+	if err := os.WriteFile(filepath.Join(subDirectory, "my_file.txt"), []byte("example data\n"), 0666); err != nil {
 		fmt.Println("create file error")
+		panic(err)
+		os.Exit(1)
+	}
+
+	if err := os.Symlink(filepath.Join(subDirectory, "my_file.txt"), filepath.Join(subDirectory, "my_link")); err != nil {
+		fmt.Println("create symlink error")
 		panic(err)
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/walle/targz
+
+go 1.17

--- a/targz.go
+++ b/targz.go
@@ -213,30 +213,19 @@ func writeTarGz(path string, tarWriter *tar.Writer, fileInfo os.FileInfo, subPat
 	}
 	defer file.Close()
 
-	evaledPath, err := filepath.EvalSymlinks(path)
+	header, err := tar.FileInfoHeader(fileInfo, path)
 	if err != nil {
 		return err
 	}
-
-	subPath, err = filepath.EvalSymlinks(subPath)
-	if err != nil {
-		return err
-	}
-
-	link := ""
-	if evaledPath != path {
-		link = evaledPath
-	}
-
-	header, err := tar.FileInfoHeader(fileInfo, link)
-	if err != nil {
-		return err
-	}
-	header.Name = evaledPath[len(subPath):]
+	header.Name = path[len(subPath):]
 
 	err = tarWriter.WriteHeader(header)
 	if err != nil {
 		return err
+	}
+
+	if !fileInfo.Mode().IsRegular() {
+		return nil
 	}
 
 	_, err = io.Copy(tarWriter, file)

--- a/targz.go
+++ b/targz.go
@@ -207,14 +207,9 @@ func writeDirectory(directory string, tarWriter *tar.Writer, subPath string) err
 
 // Write path without the prefix in subPath to tar writer.
 func writeTarGz(path string, tarWriter *tar.Writer, fileInfo os.FileInfo, subPath string) error {
-	file, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
 	var link string
 	if fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink {
+		var err error
 		if link, err = os.Readlink(path); err != nil {
 			return err
 		}
@@ -234,6 +229,12 @@ func writeTarGz(path string, tarWriter *tar.Writer, fileInfo os.FileInfo, subPat
 	if !fileInfo.Mode().IsRegular() {
 		return nil
 	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
 
 	_, err = io.Copy(tarWriter, file)
 	if err != nil {

--- a/targz.go
+++ b/targz.go
@@ -131,9 +131,9 @@ func makeAbsolute(inputFilePath, outputFilePath string) (string, string, error) 
 	return inputFilePath, outputFilePath, err
 }
 
-// The main interaction with tar and gzip. Creates a archive and recursivly adds all files in the directory.
+// The main interaction with tar and gzip. Creates a archive and recursively adds all files in the directory.
 // The finished archive contains just the directory added, not any parents.
-// This is possible by giving the whole path exept the final directory in subPath.
+// This is possible by giving the whole path except the final directory in subPath.
 func compress(inPath, outFilePath, subPath string) (err error) {
 	files, err := ioutil.ReadDir(inPath)
 	if err != nil {
@@ -180,7 +180,7 @@ func compress(inPath, outFilePath, subPath string) (err error) {
 	return nil
 }
 
-// Read a directy and write it to the tar writer. Recursive function that writes all sub folders.
+// Read a directory and write it to the tar writer. Recursive function that writes all sub folders.
 func writeDirectory(directory string, tarWriter *tar.Writer, subPath string) error {
 	files, err := ioutil.ReadDir(directory)
 	if err != nil {
@@ -213,7 +213,14 @@ func writeTarGz(path string, tarWriter *tar.Writer, fileInfo os.FileInfo, subPat
 	}
 	defer file.Close()
 
-	header, err := tar.FileInfoHeader(fileInfo, path)
+	var link string
+	if fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink {
+		if link, err = os.Readlink(path); err != nil {
+			return err
+		}
+	}
+
+	header, err := tar.FileInfoHeader(fileInfo, link)
 	if err != nil {
 		return err
 	}

--- a/targz_test.go
+++ b/targz_test.go
@@ -222,9 +222,13 @@ func createTestData() (string, string) {
 		panic(err)
 	}
 
-	_, err = os.Create(filepath.Join(subDirectory, "my_file.txt"))
-	if err != nil {
+	if err := os.WriteFile(filepath.Join(subDirectory, "my_file.txt"), []byte("file contents"), 0666); err != nil {
 		fmt.Println("Create file error")
+		panic(err)
+	}
+
+	if err := os.Symlink(filepath.Join(subDirectory, "my_file.txt"), filepath.Join(subDirectory, "my_file.link")); err != nil {
+		fmt.Println("Create symlink error")
 		panic(err)
 	}
 


### PR DESCRIPTION
I'm using this package in a Docker image I maintain and [an issue](https://github.com/offen/docker-volume-backup/issues/21) was raised where it seems that `targz` seems to  fail on symlinks that point to non-empty files, failing with:

```
archive/tar: write too long
```

It seems this is due to the fact that package `targz` resolves symlinks to use the proper file instead, but still uses the `fileInfo` of the symlink itself, which means the size written to the header info does not match anymore.

As for how to fix this there are two options:

1. Have package `targz` use the default behavior of the `tar` command which is keeping the symlink a symlink (potentially risking a broken symlink that points to something out of the bounds of the archive)
2. Have package `targz` use the behavior that seems to be the one intended by the code (but isn't working), which is to resolve the symlinks and include their backing content

I opted for choosing 1 for now as it's the default of `tar`, but if you feel like 2 is the better fit for this package I am happy to change this as again.

---

As for the issue itself, you can repro this easily by checking out the first commit in this changeset which just updates the test setup to include a symlink to a non-empty file, which makes tests fail.